### PR TITLE
v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.12.0] - 2018-11-15
+### Added
+- The special fragment `#top` is now supported for scrolling to the top, but only if no element with id `top` is found
+- After navigating to an anchor, the respective hash is now appended to the URL using `history.pushState()` to match default browser behavior.
+- When a hashchange event occurs, the polyfill tries to cancel the instant jumping scroll to the new hash, handling it with the smooth scroll instead.
+- When navigating to an anchor, the anchor is now focused.
+- In browsers supporting the optional `preventScroll` argument, the anchor is focused immediately and the focus scroll is prevented by passing this argument.
+- If the browser doesn't support `preventScroll` (e.g. Internet Explorer), the focus is scheduled to happen 450ms after the smooth scroll started so it does not interfere with the smooth scrolling (which caused flickering).
+
+
+### Changed
+- The flag to enforce the polyfill (even if the browser has native support) is now called (`window.__forceSmoothscrollAnchorPolyfill__`). The docs have been updated to reflect this. 
+
+
+### Fixed
+- The polyfill now properly handles Shift/Meta keys and allows for opening links in new windows by shift-clicking instead of preventing it with `event.preventDefault()`
+- The docs website now works in Internet Explorer 9, polyfills for `Element.classList`, `requestAnimationFrame` + an alternative for flexbox layouts have been added

--- a/index.css
+++ b/index.css
@@ -70,13 +70,24 @@ section, .fullscreen {
 
 .fullscreen {
   height: 100vh;
+  text-align: center;
 }
 
 .fullscreen {
+  position: relative;
+}
+
+html:not(.flex-center) .fullscreen>div {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.flex-center .fullscreen {
   display: flex;
   justify-content: center;
   align-items: center;
-  text-align: center;
 }
 
 .fullscreen p {

--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
     <link rel="stylesheet" href="https://unpkg.com/milligram@1.3.0/dist/milligram.css">
     <link rel="stylesheet" href="./index.css">
 
-    <!-- Hide header after scroll (mobile only) -->
     <script>
+      // Hide header after scroll (mobile only)
       document.addEventListener('DOMContentLoaded', function () {
         var d = document, bd = d.body, bdClass = bd.classList;
         var prevScrollPos = d.documentElement.scrollTop || bd.scrollTop;
@@ -48,7 +48,7 @@
           <li><a class="button" href="#docs">Docs</a></li>
           <li><a class="button" href="#legal">Legal</a></li>
           <li></li>
-          <li><a href="#">⬆ to Top</a></li>
+          <li><a href="#top">⬆ to Top</a></li>
         </ul>
       </nav>
     </header>
@@ -203,25 +203,7 @@ if (!('scrollBehavior') in document.documentElement.style) {
         <p>No.</p>
       </section>
       <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
       <!-- Way too big legal section  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
-      <!--  -->
       <section id="legal">
         <label class="label-inline" for="language">Show in German? (<b>Deutsch</b>)</label>
         <input type="checkbox" name="language" id="language">
@@ -330,27 +312,13 @@ if (!('scrollBehavior') in document.documentElement.style) {
             Daten
             unmittelbar auf Ihre Person bezogen werden:</p>
           <ul>
-            <li>
-              Besuchte Website
-            </li>
-            <li>
-              Uhrzeit zum Zeitpunkt des Zugriffes
-            </li>
-            <li>
-              Menge der gesendeten Daten in Bytes
-            </li>
-            <li>
-              Quelle/Verweis, von welchem Sie auf diese Seite gelangten
-            </li>
-            <li>
-              Verwendeter Browser
-            </li>
-            <li>
-              Verwendetes Betriebssystem
-            </li>
-            <li>
-              Verwendete IP-Adresse
-            </li>
+            <li>Besuchte Website</li>
+            <li>Uhrzeit zum Zeitpunkt des Zugriffes</li>
+            <li>Menge der gesendeten Daten in Bytes</li>
+            <li>Quelle/Verweis, von welchem Sie auf diese Seite gelangten</li>
+            <li>Verwendeter Browser</li>
+            <li>Verwendetes Betriebssystem</li>
+            <li>Verwendete IP-Adresse</li>
           </ul>
           <p>Diese Seite verwendet den Dienst <a href="https://fonts.google.com"
               target="_blank" rel="noopener">Google Fonts</a>, um verschiedene
@@ -458,8 +426,8 @@ if (!('scrollBehavior') in document.documentElement.style) {
       </div>
     </footer>
 
-    <!-- Update URL when clicking on title without triggering navigation -->
     <script>
+      // Update URL when clicking on title without triggering navigation
       Array.prototype.slice.call(document.querySelectorAll('h1[id],h2[id],h3[id],h4[id],h1[data-to],h2[data-to],h3[data-to],h4[data-to]'))
         .forEach(function (element) {
           element.addEventListener('click', function () {
@@ -469,7 +437,7 @@ if (!('scrollBehavior') in document.documentElement.style) {
               var url = location.href;
 
               if (url.indexOf('#') > 0) url = url.replace(/#.*$/, '#' + to);
-              else url = url + '#' + to;
+              else url += '#' + to;
 
               history.replaceState(null, document.title, url);
             }

--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@ if (!('scrollBehavior') in document.documentElement.style) {
           support</h3>
         <div class="row row-wrap">
           <div class="column column-40" style="flex-grow:1;max-width:100%;overflow:auto;">
-            <code>window.__forceSmoothScrollAnchorPolyfill__</code>:
+            <code>window.__forceSmoothscrollAnchorPolyfill__</code>:
           </div>
           <div class="column column-60" style="flex-grow:1;max-width:100%;">
             <p>If this is set to <code>true</code>, anchor navigation

--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>smoothscroll-anchor-polyfill</title>
+    <script>
+      // Some Polyfills for Internet Explorer 9, needed for this page
+      // Super cheap requestAnimationFrame polyfill
+      'requestAnimationFrame' in window || (window.requestAnimationFrame = function (a) { setTimeout(a, 0) });
+      // Element.classList polyfill
+      ; (function () { function a(e) { this.element = e } var b = function (e) { return e.replace(/^\s+|\s+$/g, '') }, c = function (e) { return new RegExp('(^|\\s+)' + e + '(\\s+|$)') }, d = function (e, f, g) { for (var h = 0; h < e.length; h++)f.call(g, e[h]) }; a.prototype = { add: function add() { d(arguments, function (e) { this.contains(e) || (this.element.className = b(this.element.className + ' ' + e)) }, this) }, remove: function remove() { d(arguments, function (e) { this.element.className = b(this.element.className.replace(c(e), ' ')) }, this) }, toggle: function toggle(e) { return this.contains(e) ? (this.remove(e), !1) : (this.add(e), !0) }, contains: function contains(e) { return c(e).test(this.element.className) }, item: function item(e) { return this.element.className.split(/\s+/)[e] || null }, replace: function replace(e, f) { this.remove(e), this.add(f) } }, 'classList' in Element.prototype || Object.defineProperty(Element.prototype, 'classList', { get: function get() { return new a(this) } }), window.DOMTokenList && !DOMTokenList.prototype.replace && (DOMTokenList.prototype.replace = a.prototype.replace) })();
+    </script>
     <!-- Use some polyfill for the smoothscroll JavaScript API -->
     <script src="https://unpkg.com/smoothscroll-polyfill"></script>
     <!-- Use this polyfill to apply the JS smoothscroll to anchor links -->
@@ -18,24 +25,7 @@
 
     <script>
       // Hide header after scroll (mobile only)
-      document.addEventListener('DOMContentLoaded', function () {
-        var d = document, bd = d.body, bdClass = bd.classList;
-        var prevScrollPos = d.documentElement.scrollTop || bd.scrollTop;
-
-        d.addEventListener('scroll', function () {
-          var scrollPos = d.documentElement.scrollTop || bd.scrollTop;
-          var distance = scrollPos - prevScrollPos;
-
-          // Only react if user scrolled more than 25px
-          if (Math.abs(distance) < 25) return;
-
-          // Show or hide header depending on scroll direction
-          if (distance > 0) bdClass.add('hide-header');
-          else bdClass.remove('hide-header');
-
-          prevScrollPos = scrollPos;
-        }, false);
-      })
+      document.addEventListener('DOMContentLoaded', function () { var a = document, b = a.body, c = b.classList, e = a.documentElement.scrollTop || b.scrollTop; a.addEventListener('scroll', function () { var f = a.documentElement.scrollTop || b.scrollTop, g = f - e; 25 > Math.abs(g) || (0 < g ? c.add('hide-header') : c.remove('hide-header'), e = f) }, !1) });
     </script>
   </head>
 
@@ -428,21 +418,9 @@ if (!('scrollBehavior') in document.documentElement.style) {
 
     <script>
       // Update URL when clicking on title without triggering navigation
-      Array.prototype.slice.call(document.querySelectorAll('h1[id],h2[id],h3[id],h4[id],h1[data-to],h2[data-to],h3[data-to],h4[data-to]'))
-        .forEach(function (element) {
-          element.addEventListener('click', function () {
-            var to = element.id || element.getAttribute('data-to');
-
-            if (to !== null && to !== undefined) {
-              var url = location.href;
-
-              if (url.indexOf('#') > 0) url = url.replace(/#.*$/, '#' + to);
-              else url += '#' + to;
-
-              history.replaceState(null, document.title, url);
-            }
-          })
-        });
+      ; Array.prototype.slice.call(document.querySelectorAll('h1[id],h2[id],h3[id],h4[id],h1[data-to],h2[data-to],h3[data-to],h4[data-to]')).forEach(function (a) { a.addEventListener('click', function () { var b = a.id || a.getAttribute('data-to'); if (null !== b && b !== void 0) { var c = location.href; 0 < c.indexOf('#') ? c = c.replace(/#.*$/, '#' + b) : c += '#' + b, history.replaceState(null, document.title, c) } }) });
+      // Flexbox feature detect
+      ; (function (d) { ('alignItems' in d.documentElement.style) && (d.documentElement.className += " flex-center") })(document)
     </script>
   </body>
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
   var isBrowser = typeof window !== 'undefined';
 
   // Abort if run outside browser or if smoothscroll is natively supported and
-  // __forceSmoothScrollAnchorPolyfill is not set to true by user
-  if (!isBrowser || window.__forceSmoothScrollAnchorPolyfill__ !== true && 'scrollBehavior' in document.documentElement.style) {
+  // __forceSmoothscrollAnchorPolyfill__ is not set to true by user
+  if (!isBrowser || window.__forceSmoothscrollAnchorPolyfill__ !== true && 'scrollBehavior' in document.documentElement.style) {
     return;
   }
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,21 @@
   }
 
   /**
+   * Focuses an element, if it's not focused after the first try,
+   * allow focusing by adjusting tabIndex and retry
+   * @param {HTMLElement} el
+   */
+  function focusElement(el) {
+    el.focus();
+    if (document.activeElement !== el) {
+      el.setAttribute('tabIndex', '-1');
+      // TODO: Only remove outline if it comes from the UA, not the user CSS
+      el.style.outline = 'none';
+      el.focus();
+    }
+  }
+
+  /**
    * Walks up the DOM starting from a given element until an element satisfies the validate function
    * @param {HTMLElement} element The element from where to start validating
    * @param {Function} validate The validation function
@@ -64,8 +79,13 @@
     if (isScrollTop || target) {
       evt.preventDefault();
 
-      if (isScrollTop) window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-      else target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      if (isScrollTop) {
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+        focusElement(document.body);
+      } else {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        focusElement(target);
+      }
     }
 
   }

--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@
    * @param {event} evt
    */
   function handleClick(evt) {
+    // Abort if shift/ctrl-click or not primary click (button !== 0)
+    if (evt.metaKey || evt.ctrlKey || evt.shiftKey || evt.button !== 0) return;
+
     var clickTarget = getEventTarget(evt);
     var anchor = findInParents(clickTarget, isAnchorToLocalElement);
     if (!anchor) return;

--- a/index.js
+++ b/index.js
@@ -19,19 +19,16 @@
 
   /**
    * Check if an element is an anchor pointing to a target on the current page
-   * @param {HTMLElement} element
+   * @param {HTMLElement} el
    */
-  function isAnchorToLocalElement(element) {
-    var localHostname = location.hostname;
-    var localPathname = location.pathname;
-
+  function isAnchorToLocalElement(el) {
     return (
       // Is an anchor
-      element.tagName && element.tagName.toLowerCase() === 'a' &&
+      el.tagName && el.tagName.toLowerCase() === 'a' &&
       // Targets an element
-      element.href.indexOf('#') > 0 &&
+      el.href.indexOf('#') > -1 &&
       // Target is on current page
-      element.hostname === localHostname && element.pathname === localPathname
+      el.hostname === location.hostname && el.pathname === location.pathname
     );
   }
 
@@ -48,7 +45,9 @@
   }
 
   /**
-   * Check if the clicked target is an anchor pointing to a local element, if so prevent the default behavior and handle the scrolling using the native JavaScript scroll APIs so smoothscroll-Polyfills apply
+   * Check if the clicked target is an anchor pointing to a local element,
+   * if so prevent the default behavior and handle the scrolling using the
+   * native JavaScript scroll APIs so smoothscroll polyfills apply
    * @param {event} evt
    */
   function handleClick(evt) {

--- a/index.js
+++ b/index.js
@@ -48,17 +48,33 @@
 
   /**
    * Focuses an element, if it's not focused after the first try,
-   * allow focusing by adjusting tabIndex and retry
+   * allows focusing by adjusting tabIndex and retry
    * @param {HTMLElement} el
    */
   function focusElement(el) {
     el.focus({ preventScroll: true });
     if (document.activeElement !== el) {
-      el.setAttribute('tabIndex', '-1');
+      el.setAttribute('tabindex', '-1');
       // TODO: Only remove outline if it comes from the UA, not the user CSS
       el.style.outline = 'none';
       el.focus({ preventScroll: true });
     }
+  }
+
+  /**
+   * Returns the element whose id matches the hash or
+   * document.body if the hash is "#top" or "" (empty string)
+   * @param {string} hash
+   */
+  function getScrollTarget(hash) {
+    if (typeof hash !== 'string') return null;
+
+    // Retrieve target if an id is specified in the hash, otherwise use body.
+    // If hash is "#top" and no target with id "top" was found, also use body
+    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href
+    var target = hash ? document.getElementById(hash.slice(1)) : document.body;
+    if (hash === '#top' && !target) target = document.body;
+    return target;
   }
 
   /**
@@ -77,6 +93,27 @@
   var pendingFocusChange;
 
   /**
+   * Scrolls to a given element or to the top if the given element
+   * is document.body, then focuses the element
+   * @param {HTMLElement} target
+   */
+  function triggerSmoothscroll(target) {
+    // Clear potential pending focus change triggered by a previous scroll
+    if (!supportsPreventScroll) window.clearTimeout(pendingFocusChange);
+
+    // Use JS scroll APIs to scroll to top (if target is body) or to the element
+    // This allows polyfills for these APIs to do their smooth scrolling magic
+    var scrollTop = target === document.body;
+    if (scrollTop) window.scroll({ top: 0, left: 0, behavior: 'smooth' });
+    else target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+    // If the browser supports preventScroll: immediately focus the target
+    // Otherwise schedule the focus so the smoothscroll isn't interrupted
+    if (supportsPreventScroll) focusElement(target);
+    else pendingFocusChange = setTimeout(focusElement.bind(null, target), 450);
+  }
+
+  /**
    * Check if the clicked target is an anchor pointing to a local element,
    * if so prevent the default behavior and handle the scrolling using the
    * native JavaScript scroll APIs so smoothscroll polyfills apply
@@ -86,38 +123,75 @@
     // Abort if shift/ctrl-click or not primary click (button !== 0)
     if (evt.metaKey || evt.ctrlKey || evt.shiftKey || evt.button !== 0) return;
 
-    var clickTarget = getEventTarget(evt);
     // Check the DOM from the click target upwards if a local anchor was clicked
-    var anchor = findInParents(clickTarget, isAnchorToLocalElement);
+    var anchor = findInParents(getEventTarget(evt), isAnchorToLocalElement);
     if (!anchor) return;
 
+    // Find the element targeted by the hash
     var hash = anchor.hash;
-
-    // Retrieve target if an id is specified in the hash, otherwise use body.
-    // If hash is "#top" and no target with id "top" was found, also use body
-    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href
-    var target = hash ? document.getElementById(hash.slice(1)) : document.body;
-    if (hash === '#top' && !target) target = document.body;
+    var target = getScrollTarget(hash);
 
     if (target) {
       // Prevent default browser behavior to avoid a jump to the anchor target
       evt.preventDefault();
-      // Clear potential pending focus change triggered by a previous scroll
-      if (!supportsPreventScroll) window.clearTimeout(pendingFocusChange);
 
-      // Use scroll APIs to scroll to top (if target is body) or to the element
-      // This allows polyfills for these APIs to do their smooth scrolling magic
-      var scrollTop = target === document.body;
-      if (scrollTop) window.scroll({ top: 0, left: 0, behavior: 'smooth' });
-      else target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // Trigger the smooth scroll
+      triggerSmoothscroll(target);
 
-      // If the browser supports preventScroll: immediately focus the target
-      // Otherwise schedule the focus so the smoothscroll isn't interrupted
-      if (supportsPreventScroll) focusElement(target);
-      else pendingFocusChange = setTimeout(focusElement, 450, target);
+      // Append the hash to the URL
+      if (history.pushState) {
+        history.pushState(null, document.title, (hash || '#'));
+      }
     }
 
   }
 
+  /**
+   * Returns the scroll offset towards the top
+   */
+  function getScrollTop() {
+    return document.documentElement.scrollTop || document.body.scrollTop;
+  }
+
+  /**
+   * Tries to undo the automatic, instant scroll caused by a hashchange
+   * and instead scrolls smoothly to the new hash target
+   */
+  function attachHashchangeListener() {
+    // Some browsers don't trigger a scroll event before the hashchange,
+    // so to undo, the position last reported is the one we need to go back to.
+    // In others (e.g. IE) the scroll listener is triggered before the
+    // hashchange occurs, thus the last reported position is already the new one
+    // updated by the hashchange – we need the second last to undo.
+    var lastTwoScrollPos = [];
+
+    // Keep the scroll positions up to date
+    document.addEventListener('scroll', function () {
+      lastTwoScrollPos[0] = lastTwoScrollPos[1];
+      lastTwoScrollPos[1] = getScrollTop();
+    });
+
+    window.addEventListener("hashchange", function () {
+      var target = getScrollTarget(location.hash);
+      if (!target) return;
+
+      // If the position last reported by the scroll listener is the same as the
+      // current one caused by a hashchange, go back to second last – else last
+      var currentPos = getScrollTop();
+      var top = lastTwoScrollPos[lastTwoScrollPos[1] === currentPos ? 0 : 1];
+
+      // Undo the scroll caused by the hashchange...
+      window.scroll({ top: top, behavior: 'instant' });
+      // ...and instead smoothscroll to the target
+      triggerSmoothscroll(target);
+    });
+  }
+
+  // Attach listeners if body is already available, else wait until DOM is ready
+  if (document.body) attachHashchangeListener();
+  else document.addEventListener("DOMContentLoaded", attachHashchangeListener);
+
+  // Register the click handler listening for clicks on anchor links
   document.addEventListener('click', handleClick, false);
-})()
+
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothscroll-anchor-polyfill",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Apply smooth scroll to anchor links to replicate CSS scroll-behavior",
   "main": "dist/index.js",
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothscroll-anchor-polyfill",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Apply smooth scroll to anchor links to replicate CSS scroll-behavior",
   "main": "dist/index.js",
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothscroll-anchor-polyfill",
-  "version": "0.10.6",
+  "version": "0.11.0",
   "description": "Apply smooth scroll to anchor links to replicate CSS scroll-behavior",
   "main": "dist/index.js",
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothscroll-anchor-polyfill",
-  "version": "0.9.4",
+  "version": "0.10.4",
   "description": "Apply smooth scroll to anchor links to replicate CSS scroll-behavior",
   "main": "dist/index.js",
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothscroll-anchor-polyfill",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Apply smooth scroll to anchor links to replicate CSS scroll-behavior",
   "main": "dist/index.js",
   "browserslist": [


### PR DESCRIPTION
## Focus Management

When navigating to an anchor, the anchor is now focused. Since `focus()` automatically scrolls (not smooth) to the focused element by default, this needed some workarounds:  
  - In browsers supporting the optional `preventScroll` argument, the anchor is focused immediately and the focus scroll is prevented by passing this argument.
  - If the browser doesn't support it however (Internet Explorer), the focus is scheduled to happen 450ms after the smooth scroll started so the focus scroll does not (or if, only at the very end) mess with the smooth scrolling.

## Hash support

After navigating to an anchor, the respective hash is now appended to the URL using `history.pushState()` to match default browser behavior. This allows navigating with the browser's forwards / backwards buttons.
When a hashchange event occurs, the polyfill tries to cancel the instant, jumping scroll to the new hash, handling it with the smooth scroll instead.

## Other

  - The special fragment `#top` is now supported for scrolling to the top, but only if no element with id `top` is found
  - The flag to enforce the polyfill (even if the browser has native support) is now called (`window.__forceSmoothscrollAnchorPolyfill__`)
  - The polyfill now properly handles Shift/Meta keys and allows for opening links in new windows by shift-clicking instead of preventing it with `event.preventDefault()`
  - Changelog added